### PR TITLE
feat: 单页面多路由支持

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -8,6 +8,8 @@ const glob = require('glob').sync;
 const ImportHelper = require('./import-helper');
 const DefineHelper = require('./define-helper');
 
+const hasOwn = Object.prototype.hasOwnProperty;
+
 function traverseTree(tree, enter, leave) {
   Object.keys(tree).forEach((key) => {
     const hasChild = typeof tree[key] === 'object';
@@ -54,13 +56,23 @@ function isExists(ctx, name) {
   }
 }
 
+function isRetain(metaInfo, config) {
+  // me.json中retain配置优先
+  return !!(hasOwn.call(metaInfo, 'retain') ? metaInfo.retain : config.retain);
+}
+
+function getSense(route) {
+  if (!route || typeof route !== 'string') return '';
+  // "/abc/:def" => "abc"
+  return route.replace(/^\/([^:/]+).*/, '$1');
+}
+
 exports.component = function (components, config, ctx) {
   const importHelper = new ImportHelper();
 
   importHelper.addDependencies('rrc-loader-helper/lib/fake-react');
   importHelper.addDependencies('redux', '{ combineReducers }');
   importHelper.addDependencies('rrc-loader-helper/lib/loadable', 'Loadable');
-  importHelper.addDependencies('rrc-loader-helper/lib/page-loader/async', 'asyncPageCallback');
 
   let resultStr = '';
   const currentPath = ['.'];
@@ -82,23 +94,20 @@ exports.component = function (components, config, ctx) {
         const compName = currentPath.slice(1).join('_');
         let component;
         const reducerKey = currentPath.slice(1).join('/');
-        // me.json中retain配置优先
-        const retain = Object.prototype.hasOwnProperty.call(metaInfo, 'retain') ? metaInfo.retain : config.retain;
-        if (metaInfo.sync) {
-          const comp = JSON.stringify(`${currentPath.join('/')}/view.jsx`);
-          component = `Loadable({ retain: ${JSON.stringify(retain)}, page:${JSON.stringify(reducerKey)}, loading: Loading, loader: () =>`
-            + ` new Promise(resolve => require.ensure([${comp}], require => resolve(require(${comp})),${JSON.stringify(compName)}))`
-            + ' })';
-        } else {
-          const comp = JSON.stringify(`${currentPath.join('/')}/me.json`);
-          component = `Loadable({ retain: ${JSON.stringify(retain)}, page:${JSON.stringify(reducerKey)},loading: Loading, loader: () => `
-           + `new Promise(resolve => require.ensure([${comp}], require => resolve(require(${comp})),${JSON.stringify(compName)})).then(module => asyncPageCallback(module, "${reducerKey}", reducers))})`;
-        }
+        const retain = isRetain(metaInfo, config);
+        const comp = JSON.stringify(`${currentPath.join('/')}/${metaInfo.sync ? 'view.jsx' : 'me.json'}`);
+        component = `Loadable({ sync: ${!!metaInfo.sync}, reducers, retain: ${retain}, page: "${reducerKey}", loading: Loading, loader: () => `
+            + `new Promise(resolve => require.ensure([${comp}], require => resolve(require(${comp})), "${compName}"))})`;
         if (key === config.index) {
           resultStr += `<Route exact path="/${currentPath.slice(1, -1).join('/')}" component={${component}} /> \n`;
         }
-        resultStr += `<Route path="/${currentPath.slice(1).join('/')}${metaInfo.route || ''}" `
-          + `component={ ${component} }/>\n`;
+        const routes = [].concat(metaInfo.route);
+        routes.forEach((route) => {
+          component = `Loadable({ sense: "${getSense(route)}", sync: ${!!metaInfo.sync}, reducers, retain: ${retain}, page: "${reducerKey}", loading: Loading, loader: () => `
+            + `new Promise(resolve => require.ensure([${comp}], require => resolve(require(${comp})), "${compName}"))})`;
+          resultStr += `<Route path="/${currentPath.slice(1).join('/')}${route || ''}" `
+            + `component={ ${component} }/>\n`;
+        });
       }
     }
   }, () => currentPath.pop());

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -95,15 +95,16 @@ exports.component = function (components, config, ctx) {
         let component;
         const reducerKey = currentPath.slice(1).join('/');
         const retain = isRetain(metaInfo, config);
+        const isRoutes = Array.isArray(metaInfo.route);
         const comp = JSON.stringify(`${currentPath.join('/')}/${metaInfo.sync ? 'view.jsx' : 'me.json'}`);
-        component = `Loadable({ sync: ${!!metaInfo.sync}, reducers, retain: ${retain}, page: "${reducerKey}", loading: Loading, loader: () => `
+        component = `Loadable({ routes: ${isRoutes}, sync: ${!!metaInfo.sync}, reducers, retain: ${retain}, page: "${reducerKey}", loading: Loading, loader: () => `
             + `new Promise(resolve => require.ensure([${comp}], require => resolve(require(${comp})), "${compName}"))})`;
         if (key === config.index) {
           resultStr += `<Route exact path="/${currentPath.slice(1, -1).join('/')}" component={${component}} /> \n`;
         }
         const routes = [].concat(metaInfo.route);
         routes.forEach((route) => {
-          component = `Loadable({ sense: "${getSense(route)}", sync: ${!!metaInfo.sync}, reducers, retain: ${retain}, page: "${reducerKey}", loading: Loading, loader: () => `
+          component = `Loadable({ sense: "${getSense(route)}", routes: ${isRoutes}, sync: ${!!metaInfo.sync}, reducers, retain: ${retain}, page: "${reducerKey}", loading: Loading, loader: () => `
             + `new Promise(resolve => require.ensure([${comp}], require => resolve(require(${comp})), "${compName}"))})`;
           resultStr += `<Route path="/${currentPath.slice(1).join('/')}${route || ''}" `
             + `component={ ${component} }/>\n`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-component-loader",
-  "version": "5.0.0-alpha1",
+  "version": "40.0.9",
   "description": "as title",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
1. me.json中可配置多个路由信息，如：
```json
{
  "route": ["/add", "/edit/:id"]
}
```
原单路由配置仍支持；
2. Loadable组件将会接收到新参数，`sense`，表示当前所在页面，如`add` / `edit`;
